### PR TITLE
ci,build: add initial Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: c
+sudo: required
+
+matrix:
+  include:
+    - compiler: "gcc"
+      os: linux
+      dist: xenial
+
+addons:
+  artifacts: true
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ci/travis/before_install_linux ; fi
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ci/travis/make_linux ; fi
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/ci/travis/before_install_linux
+++ b/ci/travis/before_install_linux
@@ -1,0 +1,13 @@
+#!/bin/sh -xe
+
+handle_default() {
+	sudo apt-get -qq update
+	# libstdc++-arm-none-eabi-newlib is required mostly for build
+	# there is no C++ code in this repo
+	sudo apt-get install -y gcc-arm-none-eabi \
+		libstdc++-arm-none-eabi-newlib
+}
+
+BUILD_TYPE=${BUILD_TYPE:-default}
+
+handle_${BUILD_TYPE}

--- a/ci/travis/make_linux
+++ b/ci/travis/make_linux
@@ -1,0 +1,9 @@
+#!/bin/sh -xe
+
+handle_default() {
+	make
+}
+
+BUILD_TYPE=${BUILD_TYPE:-default}
+
+handle_${BUILD_TYPE}


### PR DESCRIPTION
This changeset adds an initial structure for running builds on the `m1k-fw`
repo. We might also want to start deploying built artifacts to a storage
site (and link them in the README.md file), but that would come a bit
later.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>